### PR TITLE
Gco review

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,4 +26,6 @@ Imports:
 	ggplot2,
 	maps,
 	measurements,
-	httr
+	httr,
+  shinycssloaders,
+  DT

--- a/inst/shinyApp/global.R
+++ b/inst/shinyApp/global.R
@@ -1,31 +1,50 @@
-library(shiny)
-library(shinydashboard)
-library(shinycssloaders)
-library(data.table)
-library(ggplot2)
-library(leaflet)
-library(shinyjs)
-library(shinyalert)
-library(shinyFeedback)
-library(rmarkdown)
-library(measurements)
-library(DT)
-library(BIOMASS)
+#GCO ATTENTION Globalement éviter d'utiliser T et F à la place de TRUE et FALSE
+#GCO pour s'en rendre compte il suffit de faire T <- FALSE et le monde s'écroule :-)
+#GCO TRUE <- FALSE provoquera une erreur
+
+#GCO réduire le bruit dans la console
+suppressPackageStartupMessages({
+  library(shiny)
+  library(shinydashboard)
+  library(shinycssloaders)
+  library(data.table)
+  library(ggplot2)
+  library(leaflet)
+  library(shinyjs)
+  library(shinyalert)
+  library(shinyFeedback)
+  library(rmarkdown)
+  library(measurements)
+  library(DT)
+  library(BIOMASS)
+})
 
 # set maximum input file size (here 30Mo)
 options(shiny.maxRequestSize = 30 * 1024^2)
 
+#GCO fermeture de l'application uniquement en local (compatbilité avec le mode serveur)
+# SERVER auto close application when session ends
+# only if run locally (ie not on a remote server)
+autoCloseApp <- function(session=getDefaultReactiveDomain()) {
+  isLocal <- Sys.getenv("SHINY_PORT") == ""
+  if(isLocal) {
+    session$onSessionEnded(function() {
+      stopApp()
+    })
+  }
+}
+
+#GCO fonction générique pour ajouter un id au tag
+# UI add an id to a tag
+setId <- function(tag, id) {
+  htmltools::tagAppendAttributes(tag, id=id)
+}
+
+#GCO réécriture de boxWithId utilisant setId
+#GCO mais on pourrait aussi utiliser directement setId(box(...), id="") ou box(...) |> setId("") dans le code
 # add an id to a box so that it can be shown/hidden (instead of wrap the box() on a div() )
-boxWithId <- function(..., title = NULL, footer = NULL, status = NULL,
-                      solidHeader = FALSE, background = NULL, width = 6, height = NULL,
-                      collapsible = FALSE, collapsed = FALSE, id = NULL) {
-  b <- match.call(expand.dots = TRUE)
-  bid <- id
-  b$id <- NULL
-  b[[1]] <- as.name("box")
-  b <- eval(b, parent.frame())
-  b$attribs$id <- bid
-  b
+boxWithId <- function(..., id=NULL) {
+  box(...) |> setId(id)
 }
 
 hideMenuItem <- function(tabName) {

--- a/inst/shinyApp/server.R
+++ b/inst/shinyApp/server.R
@@ -1,9 +1,21 @@
+#GCO Globalement Attention T/F -> TRUE/FALSE
+#GCO Globalement on peut regrouper les req() en début d'observateur/render (notion de prérequis)
+#GCO Globalement Attention dans les if c'est || et && qu'il faut utiliser pas | et &
+#GCO Globalement Eviter les prints, l'utilisateur interagit avec le navigateur, pas la console
+#GCO   en plus ce ne sera pas utilisable en mode server (il n'y a pas de console)
+#GCO Globalement Attention pour observer plusieurs input il faut utiliser list() et pas {}
+#GCO   un événement est un changement de valeur, la valeur de {a;b;c;d} est d !!!
+#GCO Globalement Attention les shinyalert sont déconnectés du flux d'exécution. Elles sont
+#GCO   modales à l'écran mais ne bloquent pas l'exécution
+#GCO Globalement Je ne comprends pas la logique de l'implémentation. Le file de la fonction
+#GCO   content = function(file) est le nom d'un fichier temporaire prêt à recevoir ce qu'il
+#GCO   faut renvoyer. Pourquoi créer un autre fichier temporaire pour finalement le copier dedans ?
+#GCO Au cours de la production du rapport il ne trouve pas les champs longitude et latitude
+
 function(input, output, session) {
 
-  # stop the serveur in the end of the session
-  session$onSessionEnded(function() {
-    stopApp()
-  })
+  #GCO version compatible local/server
+  autoCloseApp()
 
   observe({
     # hide few menu at the begining
@@ -35,6 +47,7 @@ function(input, output, session) {
     showElement("box_DATASET")
     showElement("box_COORD")
 
+    #GCO ça ne devrait pas être là ! Eviter d'imbriquer les blocs réactifs
     # show forest inventory content
     output$table_DATASET <- renderDT(inv(), options = list(scrollX = TRUE))
 
@@ -163,6 +176,9 @@ function(input, output, session) {
 
 
   ## Errors management when clicking on continue ----
+  #GCO pourquoi utiliser une variable réactive pour error ? Tout tes test sont mutuellement exclusifs
+  #GCO if else if else if else ....
+  #GCO je lui aurais donné un nom plus parlant (had_error, error_occured, any_error, ...)
   error <- reactiveVal()
   observeEvent(input$btn_DATASET_LOADED, {
     print("Reaction to btn_DATASET_LOADED -> error management")

--- a/inst/shinyApp/server.R
+++ b/inst/shinyApp/server.R
@@ -260,10 +260,10 @@ function(input, output, session) {
     if (!error()) {
       newData <- inv()
       if (input$sel_DIAMETER != "<unselected>") {
-        newData[,input$sel_DIAMETER] <- conv_unit(newData[,input$sel_DIAMETER], input$rad_units_diameter, "cm")
+        newData[, var := conv_unit(var, input$rad_units_diameter, "cm"), env=list(var=input$sel_DIAMETER)]
       }
       if (input$sel_H != "<unselected>") {
-        newData[,input$sel_H] <- conv_unit(newData[,input$sel_H], input$rad_units_height, "m")
+        newData[, var := conv_unit(var, input$rad_units_diameter, "m"), env=list(var=input$sel_H)]
       }
       inv(newData)
     }


### PR DESCRIPTION
Mes commentaires rapides

Il y a aussi des nouveautés intéressantes dans data.table
depuis la version 1.15, la métaprogrammation qui permet ce genre de construction
(ici en mode extrême)
```
dt[
  filter_var %in% filter_value, 
  by=group_var, 
  var := f(var), 
  env=list(
    filter_var="species",
    filter_value=I(c("quercus", "cecropia")),
    by="plot",
    var="diameter",
    f="mean"
  )
]
```

On peut utiliser `let` à la place de `:=` (depuis la 1.15 aussi)
```
dt[, let(a=a+1)]
```

On peut utiliser .I dans le by pour faire un traitement ligne par ligne (1.15 encore)

changer plusieurs colonnes à la fois (depuis la 1.16)
dt[, names(.SD) := lapply(.SD, fx)]